### PR TITLE
fix: trending global > group

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -129,7 +129,7 @@ const Constants = {
     { name: TIME_ALL, label: 'All time' },
   ],
 
-  DEFAULT_ORDER_BY: ['trending_global', 'trending_mixed'],
+  DEFAULT_ORDER_BY: ['trending_group', 'trending_mixed'],
 
   ORDER_BY_EFFECTIVE_AMOUNT: 'effective_amount',
 


### PR DESCRIPTION
Trending mixed already takes into account the global score. This improves results a bit and is now indexed on the wallet server. Desktop was updated to match also.